### PR TITLE
fix/slice: support empty slice, include empty string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GO ?= go
 GOFMT ?= gofmt -s
 GOLINT ?= ~/go/bin/golint
 GOFILES := $(shell find . -name "*.go")
-VETPACKAGES ?= $(shell $(GO) list ./... | grep -v /examples/)
+VETPACKAGES ?= $(shell $(GO) list ./... | grep -v /examples)
 
 .PHONY: fmt
 fmt:
@@ -15,7 +15,7 @@ lint:
 	$(GOLINT) $(GOFILES)
 
 test:
-	$(GO) test -v ./...
+	$(GO) test $(VETPACKAGES)
 
 cover:
-	$(GO) test -coverprofile=prof.out && $(GO) tool cover -html=prof.out && rm prof.out
+	$(GO) test $(VETPACKAGES) -coverprofile=prof.out && $(GO) tool cover -html=prof.out && rm prof.out

--- a/codec_test.go
+++ b/codec_test.go
@@ -58,6 +58,12 @@ func TestMarshalUTF8String(t *testing.T) {
 	})
 }
 
+func TestMarshalEmptyUTF8String(t *testing.T) {
+	testMarshalBasic(t, "", func(v []byte) (interface{}, error) {
+		return ToUTF8String(v)
+	})
+}
+
 func TestMarshalInt32Slice(t *testing.T) {
 	testMarshalBasicSlice(t, []int32{123, 456}, func(v []byte) (interface{}, error) {
 		return ToInt32Slice(v)
@@ -145,13 +151,16 @@ func testMarshalBasic(t *testing.T, expected interface{}, converter func(v []byt
 	input := expected
 	codec := NewCodec(0x10)
 	inputBuf, _ := codec.Marshal(input)
-	testPrintf("inputBuf=%v\n", utils.FormatBytes(inputBuf))
+	testPrintf("inputBuf=%# x\n", inputBuf)
 
 	testDecoder(0x10, inputBuf, func(v []byte) (interface{}, error) {
 		flag = true
 		value, err := converter(v)
 		testPrintf("value=%v\n", value)
-		assert.NoError(t, err, fmt.Sprintf("decode error:%v", err))
+		if err != nil {
+			assert.Nil(t, err, ">>>>err is not nil>>>>")
+		}
+		// assert.NoError(t, err, fmt.Sprintf("decode error:%v", err))
 		assert.Equal(t, expected, value, fmt.Sprintf("value does not match(%v): %v", expected, value))
 		return value, err
 	})

--- a/encoder.go
+++ b/encoder.go
@@ -213,7 +213,7 @@ func (enc *encoder) writeTag() {
 func (enc *encoder) writeLengthBuf() {
 	// vallen := enc.valBuf.Len()
 	vallen := len(enc.valbuf)
-	if vallen < 1 {
+	if vallen < 0 {
 		panic("length must greater than 0")
 	}
 

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -139,3 +139,22 @@ func TestEncoderPrimitiveBinary(t *testing.T) {
 		}
 	}
 }
+
+// 0x01 (is a node, sequence id=1)
+//   0x04 (pvarint, node value length is 4 bytes)
+//     0x59, 0x6F, 0x4D, 0x6F (utf-8 string: "YoMo")
+func TestEncoderPrimitiveBinaryWithEmptyValue(t *testing.T) {
+	expected := []byte{0x01, 0x00}
+	// 0x01 - SeqID=1
+	var prim = NewPrimitivePacketEncoder(0x01)
+	// Value = 0x0123FF
+	prim.SetBytes([]byte{})
+
+	res := prim.Encode()
+
+	for i, p := range res {
+		if p != expected[i] {
+			t.Errorf("i=%v, expected=%v, actual=%v", i, expected[i], res[i])
+		}
+	}
+}

--- a/observable.go
+++ b/observable.go
@@ -173,6 +173,12 @@ func (o *observableImpl) Subscribe(key byte) Observable {
 							resultBuffer = append(resultBuffer, b)
 							l, e := common.DecodeLength(resultBuffer[1 : length+1]) //l 是value占字节，s是l占字节
 
+							if l == 0 {
+								next <- resultBuffer
+								reject = true
+								break
+							}
+
 							if e != nil {
 								length++
 							} else {

--- a/primitive_packet.go
+++ b/primitive_packet.go
@@ -6,8 +6,8 @@ import (
 	"github.com/yomorun/y3-codec-golang/pkg/encoding"
 )
 
-// 描述最小的Packet大小为3个字节
-const primitivePacketBufferMinimalLength = 3
+// the minimal length of a packet is 2 bytes
+const primitivePacketBufferMinimalLength = 2
 
 // PrimitivePacket 定义了值类型的节点，是Codec中的最小单位，以`TLV结构`进行数据描述
 type PrimitivePacket basePacket

--- a/primitive_test.go
+++ b/primitive_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 )
 
-// 每个Packet最小长度是3个bytes
+// 每个Packet最小长度是2个bytes
 func TestLackLengthPacket(t *testing.T) {
-	buf := []byte{0x01, 0x01}
+	buf := []byte{0x01}
 	expected := "invalid y3 packet minimal size"
 	_, _, _, err := DecodePrimitivePacket(buf)
 	if err.Error() != expected {

--- a/structure_decoder.go
+++ b/structure_decoder.go
@@ -187,7 +187,7 @@ func (d *structDecoderImpl) decodeStructFromNodePacket(fieldType reflect.Type, f
 
 	obtainedValue, flag := d.takeValueByKey(fieldName, fieldType, dataVal)
 	if !flag {
-		if d.config.ZeroFields == false {
+		if !d.config.ZeroFields {
 			return fmt.Errorf("not fond fieldName:%#x", fieldName)
 		}
 		// 用空值填充找不到的字段
@@ -217,7 +217,7 @@ func (d *structDecoderImpl) getKind(val reflect.Value) reflect.Kind {
 func (d *structDecoderImpl) takeValueByKey(fieldName string, fieldType reflect.Type, node *NodePacket) (reflect.Value, bool) {
 	key := utils.KeyOf(fieldName)
 	flag, isNode, packet := d.matchingKey(key, node)
-	if flag == false {
+	if !flag {
 		return reflect.Indirect(reflect.ValueOf(packet)), false
 	}
 	if isNode {

--- a/structure_decoder_test.go
+++ b/structure_decoder_test.go
@@ -198,6 +198,38 @@ func TestSlice(t *testing.T) {
 	testSliceFloat64(t, result.Vfloat64Slice, input.Vfloat64Slice)
 }
 
+func TestEmptySlice(t *testing.T) {
+	t.Parallel()
+
+	input := tester.SliceTestData{
+		Vfoo:          "foo",
+		Vbar:          []string{},
+		Vint32Slice:   []int32{},
+		Vint64Slice:   []int64{},
+		Vuint32Slice:  []uint32{},
+		Vuint64Slice:  []uint64{},
+		Vfloat32Slice: []float32{},
+		Vfloat64Slice: []float64{},
+	}
+
+	inputBuf, _ := newStructEncoder(0x3f, structEncoderOptionRoot(utils.RootToken)).Encode(input)
+
+	var result tester.SliceTestData
+	_, err := newStructDecoder(&result).Decode(inputBuf)
+	if err != nil {
+		t.Errorf("got an err: %s", err.Error())
+		t.FailNow()
+	}
+
+	testSliceString(t, result.Vbar, input.Vbar)
+	testSliceInt32(t, result.Vint32Slice, input.Vint32Slice)
+	testSliceInt64(t, result.Vint64Slice, input.Vint64Slice)
+	testSliceUint32(t, result.Vuint32Slice, input.Vuint32Slice)
+	testSliceUint64(t, result.Vuint64Slice, input.Vuint64Slice)
+	testSliceFloat32(t, result.Vfloat32Slice, input.Vfloat32Slice)
+	testSliceFloat64(t, result.Vfloat64Slice, input.Vfloat64Slice)
+}
+
 func TestSliceStruct(t *testing.T) {
 	t.Parallel()
 

--- a/structure_decoder_test.go
+++ b/structure_decoder_test.go
@@ -139,14 +139,14 @@ func TestArray(t *testing.T) {
 	t.Parallel()
 
 	input := tester.ArrayTestData{
-		"foo",
-		[2]string{"foo", "bar"},
-		[2]int32{1, 2},
-		[2]int64{1, 2},
-		[2]uint32{1, 2},
-		[2]uint64{1, 2},
-		[2]float32{1, 2},
-		[2]float64{1, 2},
+		Vfoo:          "foo",
+		Vbar:          [2]string{"foo", "bar"},
+		Vint32Array:   [2]int32{1, 2},
+		Vint64Array:   [2]int64{1, 2},
+		Vuint32Array:  [2]uint32{1, 2},
+		Vuint64Array:  [2]uint64{1, 2},
+		Vfloat32Array: [2]float32{1, 2},
+		Vfloat64Array: [2]float64{1, 2},
 	}
 	inputBuf, _ := newStructEncoder(0x3f, structEncoderOptionRoot(utils.RootToken)).Encode(input)
 
@@ -170,14 +170,14 @@ func TestSlice(t *testing.T) {
 	t.Parallel()
 
 	input := tester.SliceTestData{
-		"foo",
-		[]string{"foo", "bar"},
-		[]int32{1, 2},
-		[]int64{1, 2},
-		[]uint32{1, 2},
-		[]uint64{1, 2},
-		[]float32{1, 2},
-		[]float64{1, 2},
+		Vfoo:          "foo",
+		Vbar:          []string{"foo", "bar"},
+		Vint32Slice:   []int32{1, 2},
+		Vint64Slice:   []int64{1, 2},
+		Vuint32Slice:  []uint32{1, 2},
+		Vuint64Slice:  []uint64{1, 2},
+		Vfloat32Slice: []float32{1, 2},
+		Vfloat64Slice: []float64{1, 2},
 	}
 
 	inputBuf, _ := newStructEncoder(0x3f, structEncoderOptionRoot(utils.RootToken)).Encode(input)
@@ -373,9 +373,12 @@ func TestRootSliceWithSliceStruct(t *testing.T) {
 func TestNested(t *testing.T) {
 	t.Parallel()
 
-	input := tester.NestedTestData{tester.Sub1NestedTestData{tester.Sub2NestedTestData{tester.Sub3NestedTestData{
-		BasicList: []tester.BasicTestData{newBasic(), newBasic()},
-	}}}}
+	input := tester.NestedTestData{
+		SubNested: tester.Sub1NestedTestData{
+			SubNested: tester.Sub2NestedTestData{
+				SubNested: tester.Sub3NestedTestData{
+					BasicList: []tester.BasicTestData{newBasic(), newBasic()},
+				}}}}
 
 	inputBuf, _ := newStructEncoder(0x3f, structEncoderOptionRoot(utils.RootToken)).Encode(input)
 

--- a/tester.go
+++ b/tester.go
@@ -42,6 +42,7 @@ func (t *observableTester) Init(callback func(v []byte) (interface{}, error)) *o
 	go func() {
 		for c := range consumer {
 			if c != 0 {
+				//TODO: Why empty branch?
 			}
 		}
 	}()

--- a/tester.go
+++ b/tester.go
@@ -43,6 +43,7 @@ func (t *observableTester) Init(callback func(v []byte) (interface{}, error)) *o
 		for c := range consumer {
 			if c != 0 {
 				//TODO: Why empty branch?
+				testPrintf("TODO: Empty branch reached\n")
 			}
 		}
 	}()

--- a/types.go
+++ b/types.go
@@ -8,7 +8,7 @@ import (
 
 // ToObject decode bytes to interface
 func ToObject(v []byte, output interface{}) error {
-	output, err := newStructDecoder(output).Decode(v) // nolint
+	_, err := newStructDecoder(output).Decode(v) // nolint
 	return err
 }
 


### PR DESCRIPTION
- fix `go vet` warnings
- support empty slice
- support empty value
